### PR TITLE
Activate Guzzle and Monolog by default if present

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -112,7 +112,7 @@ final class Configuration implements ConfigurationInterface
 
         $node
             ->addDefaultsIfNotSet()
-            ->canBeEnabled()
+            ->canBeDisabled()
             ->children()
                 ->arrayNode('request_headers')
                     ->addDefaultsIfNotSet()
@@ -138,7 +138,7 @@ final class Configuration implements ConfigurationInterface
 
         $node
             ->addDefaultsIfNotSet()
-            ->canBeEnabled()
+            ->canBeDisabled()
             ->children()
                 ->scalarNode('extra_entry_name')
                     ->defaultValue('request_id')


### PR DESCRIPTION
Before, guzzle and monolog were activated manually. This means
developers have to know we can activate those feature when they
include Guzzle or Monolog libraries.

Now, we activate them by default if the librairies are available.